### PR TITLE
Updated Pagination Example Within cursor.skip.txt

### DIFF
--- a/source/reference/method/cursor.skip.txt
+++ b/source/reference/method/cursor.skip.txt
@@ -42,7 +42,7 @@ paginate a collection in :term:`natural order`:
    function printStudents(pageNumber, nPerPage) {
      print( "Page: " + pageNumber );
      db.students.find()
-                .skip( pageNumber > 0 ? ( ( pageNumber - 1 ) * nPerPage ) : 0 )
+                .skip( pageNumber > 0 ? ( pageNumber * nPerPage ) : 0 )
                 .limit( nPerPage )
                 .forEach( student => {
                   print( student.name );


### PR DESCRIPTION
Example previously had `.skip( pageNumber > 0 ? ( ( pageNumber - 1 ) * nPerPage ) : 0 )` but it should be `.skip( pageNumber > 0 ? ( pageNumber * nPerPage ) : 0 )`. 

Without this fix, the example would result in zero `nPerPage` getting skipped till `pageNumber` = 2.